### PR TITLE
Load the configuration so that example config file works

### DIFF
--- a/classes/Kohana/MangoDB.php
+++ b/classes/Kohana/MangoDB.php
@@ -49,11 +49,11 @@ class Kohana_MangoDB {
 			if ($config === NULL)
 			{
 				// Load the configuration for this database
-				$config = Kohana::$config->load('mangoDB.' . $name);
+				$config = Kohana::$config->load('mangoDB');
 			}
 
 			// Store the database instance
-			MangoDB::$instances[$name] = new MangoDB($name,$config);
+			MangoDB::$instances[$name] = new MangoDB($name,$config[$name]);
 		}
 
 		return self::$instances[$name];


### PR DESCRIPTION
The example config file (`config/mangoDB`) has multiple connections set as the top level keys in the configuration array - as common for database configuration in Kohana modules. But the `MangoDB::instance()` method expects the connection details to be the top level keys in a file named after the connection name.

I changed the configuration loading to work as the example file expects and as common practice in Kohana.